### PR TITLE
Allow installing alongside Django 3.2-<5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-Django = "^3.2"
+Django = ">=3.2,<5"
 boto3 = "^1.21.9"
 botocore = "^1.24.9"
 


### PR DESCRIPTION
The previous `^3.2` line would only allow installing Django less than 4.

This can be tested with the following:

```shell
pyenv local 3.10.8
python -m venv --prompt . .venv
source .venv/bin/activate
echo "Django==4.1.3" > requirements.txt
echo "django-dynamodb-cache==0.5.0" >> requirements.txt 
pip install --upgrade pip
pip install -r requirements.txt 
```

```pip install -r requirements.txt 
Collecting Django==4.1.3
  Using cached Django-4.1.3-py3-none-any.whl (8.1 MB)
Collecting django-dynamodb-cache==0.5.0
  Using cached django_dynamodb_cache-0.5.0-py3-none-any.whl (11 kB)
Collecting sqlparse>=0.2.2
  Using cached sqlparse-0.4.3-py3-none-any.whl (42 kB)
Collecting asgiref<4,>=3.5.2
  Using cached asgiref-3.6.0-py3-none-any.whl (23 kB)
Collecting botocore<2.0.0,>=1.24.9
  Using cached botocore-1.29.56-py3-none-any.whl (10.3 MB)
Collecting boto3<2.0.0,>=1.21.9
  Using cached boto3-1.26.56-py3-none-any.whl (132 kB)
INFO: pip is looking at multiple versions of <Python from Requires-Python> to determine which version is compatible with other requirements. This could take a while.
INFO: pip is looking at multiple versions of django to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install -r requirements.txt (line 2) and Django==4.1.3 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested Django==4.1.3
    django-dynamodb-cache 0.5.0 depends on Django<4.0 and >=3.2

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```
(h/t @GeoWill for the example).

This change allows installing the library alongside Django 4.1.