### PR TITLE
Add a database arg

### DIFF
--- a/django_dynamodb_cache/management/commands/createcachetable.py
+++ b/django_dynamodb_cache/management/commands/createcachetable.py
@@ -11,6 +11,13 @@ class Command(BaseCommand):
 
     requires_system_checks = []
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--database',
+            default=None,
+            help='Not used in this command (see settings.CACHES["options"] to change the table name)',
+        )
+
     def handle(self, *tablenames, **options):
         for cache_alias in settings.CACHES:
             cache = caches[cache_alias]


### PR DESCRIPTION
Django's `createcachetable` allows passing in a `database` arg.

This is called when Django creates a test database, as per:

https://github.com/django/django/blob/4.1/django/db/backends/base/creation.py#L96

This line is hit when using pytest and pytest-django, however it might also be hit in other testing setups.

The change in this commit adds a "dummy" arg to the command that fixes this problem.